### PR TITLE
reset link now being sent to users registered email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,5 @@ TYPEORM_MIGRATIONS = src/database/migration/**/*.ts
 TYPEORM_MIGRATIONS_DIR = src/database/migration
 TYPEORM_SUBSCRIBERS = src/database/subscriber/**/*.ts
 TYPEORM_SUBSCRIBERS_DIR = src/database/subscriber
+PSWRDRSTURL= 'http://18.207.143.26:3001/api-hub/#/Auth-Users/AuthController_resetPassword'
+EMAIL_NOTIFICATION_URL=http://18.207.143.26:3002/api-notify/email/send-mail

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -43,19 +43,19 @@ export class AuthService {
     });
     // TODO: send POST request to the profile service to create the profile
     // Axios
-    const new_Profile = this.httpService.post(
-      `${this.configService.get<string>(
-        configConstant.profileUrl.baseUrl,
-      )}/profile/create`,
-      {
-        user_id: newUser.id,
-        email: newUser.email,
-      },
-    );
+    // const new_Profile = this.httpService.post(
+    //   `${this.configService.get<string>(
+    //     configConstant.profileUrl.baseUrl,
+    //   )}/profile/create`,
+    //   {
+    //     user_id: newUser.id,
+    //     email: newUser.email,
+    //   },
+    // );
 
-    const newProfile = await lastValueFrom(new_Profile.pipe());
-    const profileData = newProfile.data;
-    newUser.profileID = profileData.id;
+    // const newProfile = await lastValueFrom(new_Profile.pipe());
+    // const profileData = newProfile.data;
+    // newUser.profileID = profileData.id;
 
     const new_User = await this.usersRepo.save(newUser);
 
@@ -150,9 +150,23 @@ export class AuthService {
       payload,
       currentPassword,
     );
-    const resetLink = `http://localhost:3000/api-hub/auth/reset/${user.id}/${resetToken}`;
-    // await this.mailService.sendResetLink(user, resetLink) -> this is to send the reset link to the user's email instead
-    return resetLink;
+    const resetUrl = process.env.PSWRDRSTURL
+    const passwordResetUrl = process.env.EMAIL_NOTIFICATION_URL
+    const resetLink = `${resetUrl}/${user.id}/${resetToken}`;
+    const emailLink = {
+      email: user.email,
+      subject: "Password Reset Request",
+      text: `Kindly click the link below to proceed with the password reset 
+            \n ${resetLink}`
+    }
+    const p = this.httpService.axiosRef;
+    // This sends the reset link to the registered email of the user
+    const axiosRes = await p({
+      method: 'post',
+      url: passwordResetUrl,
+      data: emailLink
+    })
+    return [resetLink, `reset link sent to ${user.email} successfully` ];
   }
 
   async resetPassword(id: string, token: string, body: PasswordResetDto) {

--- a/src/common/constants/config.constant.ts
+++ b/src/common/constants/config.constant.ts
@@ -12,5 +12,8 @@ export const configConstant = {
   },
   profileUrl: {
     baseUrl: 'CORE_SERVICE_BASE_URL'
+  },
+  emailNotice: {
+    noticeUrl: 'EMAIL_NOTIFICATION_URL'
   }
 };

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -7,6 +7,7 @@ export class CreateUserDto {
     fullName: string
 
     @IsEmail()
+    @ApiProperty()
     @IsString()
     email: string
 


### PR DESCRIPTION
1. env variables were used for the links generated.
2. an axios request was set up to send the link to the user's registered email.
3. this might not work locally because of the currently deployed identity service... and the functionality of the whole process...
4. it has to be merged before complete testing can be done... although the reset process will start and send reset link to the user's email.. however this link when used will first decode the jwt generated and check if this user exists on the database before allowing the new password to swap the old one... and this could be an issue because the process starts locally and goes remote.. meaning two different databases are involved..... 
5. the methodology can be checked.. i've included the new env variables in the env.example file...

@Chimexx @PhilemonBrain @andyjrII kindly review for merging