### PR TITLE
password reset now sent to email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,6 @@ ACCESS_TIME=
 REFRESH_TIME=
 RESET_TIME=
 RESET_SECRET=
+
+PSWRDRSTURL= 'http://18.207.143.26:3001/api-hub/#/Auth-Users/AuthController_resetPassword'
+EMAIL_NOTIFICATION_URL=http://18.207.143.26:3002/api-notify/email/send-mail

--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,5 @@ REFRESH_TIME=
 RESET_TIME=
 RESET_SECRET=
 
-PSWRDRSTURL= 'http://18.207.143.26:3001/api-hub/#/Auth-Users/AuthController_resetPassword'
+PASSWORD_RESET_URL= 'http://18.207.143.26:3001/api-hub/#/Auth-Users/AuthController_resetPassword'
 EMAIL_NOTIFICATION_URL=http://18.207.143.26:3002/api-notify/email/send-mail

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -166,7 +166,7 @@ export class AuthService {
       url: emailUrl,
       data: emailLink
     })
-    return [resetLink, `reset link sent to ${user.email} successfully` ];
+    return [resetLink, `\n reset link sent to ${user.email} successfully` ];
   }
 
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -150,10 +150,25 @@ export class AuthService {
       payload,
       currentPassword,
     );
-    const resetLink = `http://localhost:3000/api-hub/auth/reset/${user.id}/${resetToken}`;
-    // await this.mailService.sendResetLink(user, resetLink) -> this is to send the reset link to the user's email instead
-    return resetLink;
+    const resetUrl = this.configService.get(configConstant.passwordReset.resetUrl)
+    const emailUrl = this.configService.get(configConstant.passwordReset.emailUrl)
+    const resetLink = `${resetUrl}/${user.id}/${resetToken}`;
+    const emailLink = {
+      email: user.email,
+      subject: "Password Reset Request",
+      text: `Kindly click the link below to proceed with the password reset 
+            \n ${resetLink}`
+    }
+    const p = this.httpService.axiosRef;
+    // This sends the reset link to the registered email of the user
+    const axiosRes = await p({
+      method: 'post',
+      url: emailUrl,
+      data: emailLink
+    })
+    return [resetLink, `reset link sent to ${user.email} successfully` ];
   }
+
 
   async resetPassword(id: string, token: string, body: PasswordResetDto) {
     const user: User = await this.usersRepo.findOne({ where: { id } });

--- a/src/common/constants/config.constant.ts
+++ b/src/common/constants/config.constant.ts
@@ -17,4 +17,9 @@ export const configConstant = {
     nofication: 'NOTIFICATION_URL',
     identityUrl: 'IDENTITY_SERVICE_BASE_URL',
   },
+  passwordReset: {
+    resetUrl: 'PSWRDRSTURL',
+    emailUrl: 'EMAIL_NOTIFICATION_URL'
+  }
+  
 };

--- a/src/common/constants/config.constant.ts
+++ b/src/common/constants/config.constant.ts
@@ -18,7 +18,7 @@ export const configConstant = {
     identityUrl: 'IDENTITY_SERVICE_BASE_URL',
   },
   passwordReset: {
-    resetUrl: 'PSWRDRSTURL',
+    resetUrl: 'PASSWORD_RESET_URL',
     emailUrl: 'EMAIL_NOTIFICATION_URL'
   }
   

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -8,6 +8,7 @@ export class CreateUserDto {
 
     @IsEmail()
     @IsString()
+    @ApiProperty()
     email: string
 
     @IsString()


### PR DESCRIPTION
password reset link now sent to email...
NB this has to be merged before it can be tested through and through.. except the env variables wld be modified to only run locally.... (PSWRDRSTURL= 'http://18.207.143.26:3001/api-hub/#/Auth-Users/AuthController_resetPassword') This is for the hosted service.. which only works if the user is registered on the server from the onset....

@Chimexx @andyjrII @PhilemonBrain kindly review for merging